### PR TITLE
Feature/Add CompReinvestmentAdapter

### DIFF
--- a/contracts/adapters/CompReinvestmentAdapter.sol
+++ b/contracts/adapters/CompReinvestmentAdapter.sol
@@ -1,0 +1,21 @@
+pragma solidity 0.6.10;
+
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+
+import { BaseAdapter } from "../lib/BaseAdapter.sol";
+import { IBaseManager } from "../interfaces/IBaseManager.sol";
+import { ISetToken } from "../interfaces/ISetToken.sol";
+import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";
+
+contract CompReinvestmentAdapter is BaseAdapter {
+  // using Address for address;
+  // using PreciseUnitMath for uint256;
+  // using SafeMath for uint256;
+
+  // ISetToken public setToken;
+
+  constructor(IBaseManager _manager) public BaseAdapter(_manager) {
+    // setToken = manager.setToken();
+  }
+}

--- a/contracts/adapters/CompReinvestmentAdapter.sol
+++ b/contracts/adapters/CompReinvestmentAdapter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.6.10;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
@@ -5,6 +6,7 @@ import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 
 import { BaseAdapter } from "../lib/BaseAdapter.sol";
 import { IBaseManager } from "../interfaces/IBaseManager.sol";
+import { IComptroller } from "../interfaces/IComptroller.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
 import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";
 
@@ -13,9 +15,40 @@ contract CompReinvestmentAdapter is BaseAdapter {
   // using PreciseUnitMath for uint256;
   // using SafeMath for uint256;
 
-  // ISetToken public setToken;
+  /* ============ State Variables ============ */
 
-  constructor(IBaseManager _manager) public BaseAdapter(_manager) {
-    // setToken = manager.setToken();
+  ISetToken public setToken;
+
+  // Compound Comptroller contract
+  IComptroller internal comptroller;
+
+  constructor(
+    IBaseManager _manager,
+    IComptroller _comptroller
+  )
+    public
+    BaseAdapter(_manager)
+  {
+      comptroller = _comptroller;
+      setToken = manager.setToken();
   }
+
+  /* ============ External Functions ============ */
+
+  function reinvest() external onlyOperator {
+    // TODO: check comp balance, return if < 1
+    // TODO: claim comp
+    // TODO: reinvest for cETH?
+  }
+
+  /* ============ Internal Functions ============ */
+
+  function _claimableComp() internal view returns(uint256) {}
+
+  function _claimComp() internal {
+    // TODO: get correct address
+    comptroller.claimComp(address(this));
+  }
+
+  function _sellComp() internal {}
 }

--- a/contracts/adapters/CompReinvestmentAdapter.sol
+++ b/contracts/adapters/CompReinvestmentAdapter.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.6.10;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 
 import { BaseAdapter } from "../lib/BaseAdapter.sol";
@@ -11,9 +12,11 @@ import { ISetToken } from "../interfaces/ISetToken.sol";
 import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";
 
 contract CompReinvestmentAdapter is BaseAdapter {
-  // using Address for address;
-  // using PreciseUnitMath for uint256;
-  // using SafeMath for uint256;
+  using Address for address;
+  using PreciseUnitMath for uint256;
+  using SafeMath for uint256;
+
+  address public constant comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
 
   /* ============ State Variables ============ */
 
@@ -36,19 +39,30 @@ contract CompReinvestmentAdapter is BaseAdapter {
   /* ============ External Functions ============ */
 
   function reinvest() external onlyOperator {
-    // TODO: check comp balance, return if < 1
-    // TODO: claim comp
+    uint256 claimableAmount = _claimableComp();
+    // TODO: specify minimum amount to claim?
+    require(claimableAmount > 1, "Reinvestment failed - not enough COMP to claim");
+    _claimComp();
+    _sellComp();
     // TODO: reinvest for cETH?
   }
 
   /* ============ Internal Functions ============ */
 
-  function _claimableComp() internal view returns(uint256) {}
+  function _claimableComp() internal view returns(uint256) {
+    // TODO: get correct address?
+    uint256 balance = IERC20(comp).balanceOf(address(this));
+    return balance;
+  }
 
   function _claimComp() internal {
     // TODO: get correct address
     comptroller.claimComp(address(this));
   }
 
-  function _sellComp() internal {}
+  function _sellComp() internal {
+    uint256 _comp = IERC20(comp).balanceOf(address(this));
+    // TODO: sell in exchange for what token?
+    // TODO: sell via uni/sushi?
+  }
 }

--- a/test/adapters/compReinvestmentAdapter.spec.ts
+++ b/test/adapters/compReinvestmentAdapter.spec.ts
@@ -56,13 +56,19 @@ describe("CompReinvestmentAdapter", () => {
 
   describe("#constructor", async () => {
     let subjectManagerAddress: Address;
+    let comptrollerAddress: Address;
 
     beforeEach(async () => {
       subjectManagerAddress = baseManagerV2.address;
+      // TODO: set mock comptroller address
+      comptrollerAddress = baseManagerV2.address;
     });
 
     async function subject(): Promise<CompReinvestmentAdapter> {
-      return await deployer.adapters.deployCompReinvestmentAdapter(subjectManagerAddress);
+      return await deployer.adapters.deployCompReinvestmentAdapter(
+        subjectManagerAddress,
+        comptrollerAddress,
+      );
     }
 
     it("should set the manager address", async () => {

--- a/test/adapters/compReinvestmentAdapter.spec.ts
+++ b/test/adapters/compReinvestmentAdapter.spec.ts
@@ -1,0 +1,77 @@
+import "module-alias/register";
+
+import { Address, Account } from "@utils/types";
+import { CompReinvestmentAdapter, BaseManager } from "@utils/contracts/index";
+import { SetToken } from "@utils/contracts/setV2";
+import DeployHelper from "@utils/deploys";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  ether,
+  getAccounts,
+  getLastBlockTimestamp,
+  getSetFixture,
+  getStreamingFee,
+  getStreamingFeeInflationAmount,
+  getTransactionTimestamp,
+  getWaffleExpect,
+  increaseTimeAsync,
+  preciseMul,
+} from "@utils/index";
+import { SetFixture } from "@utils/fixtures";
+
+const expect = getWaffleExpect();
+
+describe("CompReinvestmentAdapter", () => {
+  let owner: Account;
+  let methodologist: Account;
+  let operator: Account;
+  let setV2Setup: SetFixture;
+
+  let deployer: DeployHelper;
+  let setToken: SetToken;
+
+  let baseManagerV2: BaseManager;
+
+  before(async () => {
+    [owner, methodologist, operator] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    setV2Setup = getSetFixture(owner.address);
+    await setV2Setup.initialize();
+
+    setToken = await setV2Setup.createSetToken(
+      [setV2Setup.dai.address],
+      [ether(1)],
+      [setV2Setup.debtIssuanceModule.address, setV2Setup.streamingFeeModule.address],
+    );
+
+    // Deploy BaseManager
+    baseManagerV2 = await deployer.manager.deployBaseManager(
+      setToken.address,
+      operator.address,
+      methodologist.address,
+    );
+  });
+
+  describe("#constructor", async () => {
+    let subjectManagerAddress: Address;
+
+    beforeEach(async () => {
+      subjectManagerAddress = baseManagerV2.address;
+    });
+
+    async function subject(): Promise<CompReinvestmentAdapter> {
+      return await deployer.adapters.deployCompReinvestmentAdapter(subjectManagerAddress);
+    }
+
+    it("should set the manager address", async () => {
+      const retrievedAdapter = await subject();
+      const manager = await retrievedAdapter.manager();
+      console.log(manager);
+      console.log(subjectManagerAddress);
+
+      expect(manager).to.eq(subjectManagerAddress);
+    });
+  });
+});

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -1,6 +1,7 @@
 export { BaseAdapterMock } from "../../typechain/BaseAdapterMock";
 export { BaseManager } from "../../typechain/BaseManager";
 export { ChainlinkAggregatorV3Mock } from "../../typechain/ChainlinkAggregatorV3Mock";
+export { CompReinvestmentAdapter } from "../../typechain/CompReinvestmentAdapter"
 export { ExchangeIssuance } from "../../typechain/ExchangeIssuance";
 export { ExchangeIssuanceV2 } from "../../typechain/ExchangeIssuanceV2";
 export { FeeSplitAdapter } from "../../typechain/FeeSplitAdapter";

--- a/utils/deploys/deployAdapters.ts
+++ b/utils/deploys/deployAdapters.ts
@@ -1,15 +1,24 @@
 import { Signer, BigNumber } from "ethers";
-import { Address, ContractSettings, MethodologySettings, ExecutionSettings, IncentiveSettings, ExchangeSettings } from "../types";
 import {
+  Address,
+  ContractSettings,
+  MethodologySettings,
+  ExecutionSettings,
+  IncentiveSettings,
+  ExchangeSettings,
+} from "../types";
+import {
+  CompReinvestmentAdapter,
   ExchangeIssuance,
   ExchangeIssuanceV2,
   FlexibleLeverageStrategyExtension,
   FeeSplitAdapter,
   GIMExtension,
   GovernanceAdapter,
-  StreamingFeeSplitExtension
+  StreamingFeeSplitExtension,
 } from "../contracts/index";
 
+import { CompReinvestmentAdapter__factory } from "../../typechain/factories/CompReinvestmentAdapter__factory";
 import { ExchangeIssuance__factory } from "../../typechain/factories/ExchangeIssuance__factory";
 import { ExchangeIssuanceV2__factory } from "../../typechain/factories/ExchangeIssuanceV2__factory";
 import { FeeSplitAdapter__factory } from "../../typechain/factories/FeeSplitAdapter__factory";
@@ -25,6 +34,16 @@ export default class DeployAdapters {
     this._deployerSigner = deployerSigner;
   }
 
+  public async deployCompReinvestmentAdapter(
+    manager: Address,
+    comptroller: Address,
+  ): Promise<CompReinvestmentAdapter> {
+    return await new CompReinvestmentAdapter__factory(this._deployerSigner).deploy(
+      manager,
+      comptroller,
+    );
+  }
+
   public async deployFeeSplitAdapter(
     manager: Address,
     streamingFeeModule: Address,
@@ -35,7 +54,7 @@ export default class DeployAdapters {
       manager,
       streamingFeeModule,
       debtIssuanceModule,
-      operatorFeeSplit
+      operatorFeeSplit,
     );
   }
 
@@ -47,7 +66,7 @@ export default class DeployAdapters {
     return await new StreamingFeeSplitExtension__factory(this._deployerSigner).deploy(
       manager,
       streamingFeeModule,
-      operatorFeeSplit
+      operatorFeeSplit,
     );
   }
 
@@ -57,7 +76,7 @@ export default class DeployAdapters {
   ): Promise<GovernanceAdapter> {
     return await new GovernanceAdapter__factory(this._deployerSigner).deploy(
       manager,
-      governanceModule
+      governanceModule,
     );
   }
 
@@ -67,7 +86,7 @@ export default class DeployAdapters {
   ): Promise<GIMExtension> {
     return await new GIMExtension__factory(this._deployerSigner).deploy(
       manager,
-      generalIndexModule
+      generalIndexModule,
     );
   }
 
@@ -78,7 +97,7 @@ export default class DeployAdapters {
     executionSettings: ExecutionSettings,
     incentiveSettings: IncentiveSettings,
     exchangeNames: string[],
-    exchangeSettings: ExchangeSettings[]
+    exchangeSettings: ExchangeSettings[],
   ): Promise<FlexibleLeverageStrategyExtension> {
     return await new FlexibleLeverageStrategyExtension__factory(this._deployerSigner).deploy(
       manager,
@@ -107,7 +126,7 @@ export default class DeployAdapters {
       sushiFactoryAddress,
       sushiRouterAddress,
       setControllerAddress,
-      basicIssuanceModuleAddress
+      basicIssuanceModuleAddress,
     );
   }
 
@@ -127,7 +146,7 @@ export default class DeployAdapters {
       sushiFactoryAddress,
       sushiRouterAddress,
       setControllerAddress,
-      basicIssuanceModuleAddress
+      basicIssuanceModuleAddress,
     );
   }
 }


### PR DESCRIPTION
## Description (Bounty)
Since launch, the ETH2x-FLI has grown to $130M in market cap. Currently, the index achieves leverage by depositing into cETH and borrowing USDC on Compound. However, the ability to claim the accrued COMP rewards is not enabled yet which is currently sitting at 250 unclaimed COMP. This This BaseManager adapter will chain together several Set Protocol Module actions to automate the COMP reinvestment process.

## Review Feedback
Would appreciate any feedback. 🙏 
* In general, is the code going into the right direction? Or would this be done completely different?
* Are there existing functions/classes that could be leveraged for the solution?
* Anything you can spot.